### PR TITLE
fix(package): fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -p ./tsconfig.json",
     "watch": "tsc -w --preserveWatchOutput -p ./tsconfig.json",
     "test": "npm-run-all -s test:*",
-    "test:behaviour": "cross-env TS_NODE_PROJECT=./test/behaviour/tsconfig.json mocha -r ts-node/register ./test/behaviour/**/*.ts",
+    "test:behaviour": "cross-env TS_NODE_PROJECT=./test/behaviour/tsconfig.json mocha -r ts-node/register \"./test/behaviour/**/*.ts\"",
     "test:types": "dtslint ./test/types"
   },
   "dependencies": {


### PR DESCRIPTION
Old test script does not work with multilevel tests, since, glob pattern in arguments of mocha is interperted by shell, not by mocha.
This is fixed by wrapping glob pattern with `\"\"`.