### PR TITLE
fix(package): restrict files field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://Ailrun.github.io"
   },
   "files": [
-    "*"
+    "./dist"
   ],
   "main": "./dist/index.js",
   "bin": {


### PR DESCRIPTION
Original files field includes unnecessary things.
This PR restrict the field so that to be able to lessen the size of published npm package.