### PR TITLE
fix(repo): fix commitlint setting to allow uppercase letters

### DIFF
--- a/config/commitlint/commitlint.config.js
+++ b/config/commitlint/commitlint.config.js
@@ -31,10 +31,14 @@ module.exports = {
     'scope-case': [
       0,
     ],
+    /**
+     * @desc
+     * Block sentence case to allow uppercase letter only after some verb or statement.
+     */
     'subject-case': [
       2,
-      'always',
-      'lowerCase',
+      'never',
+      'sentence-case',
     ],
     'subject-empty': [
       0,


### PR DESCRIPTION
Originally the commitlint setting did not allow uppercase letters in subject part of commit message.
However, there is some cases that uppercase letters are preferable, like `update createPackage function`.
Though I still want to block something like `Update createPackage function`, so I invert the rule to use `
`'never'` and pass `'sentence-case'` option to block sentence case messages.